### PR TITLE
Keep the browser default font

### DIFF
--- a/extension/browserAction.css
+++ b/extension/browserAction.css
@@ -2,10 +2,6 @@ img {
     width: 1.25rem;
     height: 1.25rem;
 }
-body {
-    font-family: monospace;
-    font-size: 1.75rem;
-}
 .left {
     padding-right: 0.875rem;
 }


### PR DESCRIPTION
At least on my setup when changing between different dpi displays (external/laptop) this somewhat gets into the way of firefox changing the font size. It looks way to big on my hidpi screen, when the font is set specifically.